### PR TITLE
Running build workflow only for main branch push

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,10 +4,8 @@ name: CI
 
 # Controls when the workflow will run
 on:
-  # Triggers the workflow on push or pull request events but only for the main branch
+  # Triggers the workflow on push events but only for the main branch
   push:
-    branches: [main]
-  pull_request:
     branches: [main]
 
   # Allows you to run this workflow manually from the Actions tab


### PR DESCRIPTION
### Summary
1. Updated GitHub workflow to run only when there is a new commit/push on `main` branch