### PR TITLE
Medha role removed from api

### DIFF
--- a/src/graphql/helper.js
+++ b/src/graphql/helper.js
@@ -54,7 +54,6 @@ query GET_ALL_USERS {
     role {
       name
     }
-    medha_role
     reports_to {
       id
       username


### PR DESCRIPTION
## Summary

1. Medha role removed from API call. This field was removed from Strapi backend.

## Test Plan

<!-- Demonstrate that the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
- [ ] Wrote tests
- [x] Tested locally