### PR TITLE
Api updates for certificate regenerate

### DIFF
--- a/src/utils/function/certificate.js
+++ b/src/utils/function/certificate.js
@@ -1,10 +1,6 @@
+import api from "../../apis";
+
 export const generateCertificate = async (programEnrollmentId) => {
-  let url = `${process.env.REACT_APP_STRAPI_API_BASEURL}/program-enrollments/${programEnrollmentId}/generateCertificate`;
-  let response = await fetch(url, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    }
-  });
-  return await response.json();
+  const url = `${process.env.REACT_APP_STRAPI_API_BASEURL}/program-enrollments/${programEnrollmentId}/generateCertificate`;
+  return await api.post(url);
 }

--- a/src/views/Batches/batchComponents/ProgramEnrollment.jsx
+++ b/src/views/Batches/batchComponents/ProgramEnrollment.jsx
@@ -76,9 +76,9 @@ const ProgramEnrollment = (props) => {
 
   const handleGenerateCertificate = async () => {
     setLoadingCertificationButton(true);
-    let response = await generateCertificate(programEnrollment.id);
-    if (response.programEnrollment) {
-      setProgramEnrollment(response.programEnrollment);
+    let { data } = await generateCertificate(programEnrollment.id);
+    if (data.programEnrollment) {
+      setProgramEnrollment(data.programEnrollment);
     }
     setLoadingCertificationButton(false);
   }

--- a/src/views/Institutions/InstitutionComponents/ProgramEnrollment.jsx
+++ b/src/views/Institutions/InstitutionComponents/ProgramEnrollment.jsx
@@ -77,9 +77,9 @@ const ProgramEnrollment = (props) => {
 
   const handleGenerateCertificate = async () => {
     setLoadingCertificationButton(true);
-    let response = await generateCertificate(programEnrollment.id);
-    if (response.programEnrollment) {
-      setProgramEnrollment(response.programEnrollment);
+    let { data } = await generateCertificate(programEnrollment.id);
+    if (data.programEnrollment) {
+      setProgramEnrollment(data.programEnrollment);
     }
     setLoadingCertificationButton(false);
   }

--- a/src/views/Students/StudentComponents/ProgramEnrollment.jsx
+++ b/src/views/Students/StudentComponents/ProgramEnrollment.jsx
@@ -79,9 +79,9 @@ const ProgramEnrollment = (props) => {
 
   const handleGenerateCertificate = async () => {
     setLoadingCertificationButton(true);
-    let response = await generateCertificate(programEnrollment.id);
-    if (response.programEnrollment) {
-      setProgramEnrollment(response.programEnrollment);
+    let { data } = await generateCertificate(programEnrollment.id);
+    if (data.programEnrollment) {
+      setProgramEnrollment(data.programEnrollment);
     }
     setLoadingCertificationButton(false);
   }


### PR DESCRIPTION
## Summary
1. Using the api/axios package instead of custom fetch
2. api/axios will add the token in the request using interceptor
3. updated code wherever we were using the response from the previous fetch call
