### PR TITLE
Updated date in opportunity details page

### DIFF
--- a/src/graphql/opportunities.js
+++ b/src/graphql/opportunities.js
@@ -4,6 +4,7 @@ type
 role_or_designation
 number_of_opportunities
 created_at
+updated_at
 status
 department_or_team
 role_description


### PR DESCRIPTION
Target #598 
Bug :
Update the date on the opportunity details page.

Changes :
in updated Date field their current date is displayed. 
We have to fix it.


